### PR TITLE
Fix panic when bounding box cannot be reprojected

### DIFF
--- a/t-rex-gdal/src/gdal_ds.rs
+++ b/t-rex-gdal/src/gdal_ds.rs
@@ -318,7 +318,13 @@ impl DatasourceInput for GdalDatasource {
         // Spatial filter must be in layer SRS
         let layer_srid = layer.srid.unwrap_or(grid.srid);
         if layer_srid != grid.srid {
-            bbox_extent = transform_extent(&bbox_extent, grid.srid, layer_srid).unwrap()
+            match transform_extent(&bbox_extent, grid.srid, layer_srid) {
+                Ok(extent) => bbox_extent = extent,
+                Err(e) => {
+                    error!("Unable to transform {:?}: {}", bbox_extent, e);
+                    return;
+                }
+            }
         };
         let bbox = Geometry::bbox(bbox_extent.minx,
                                   bbox_extent.miny,


### PR DESCRIPTION
I'm not sure if it could be handled better, but I need this for cases like:

```text
2018-02-07 16:53:20.523 ERROR Unable to transform Extent { minx: 10958012.374962863, miny: -626172.1357121691, maxx: 11271098.442818947, maxy: -313086.06785608456 }: Invalid coordinate range while transforming points from EPSG:3857 to EPSG:32633: None
```

`t-rex serve` handles panics just fine, but `t-rex generate` will crash.