### PR TITLE
Pass Attribution from config to tilejson descriptor

### DIFF
--- a/t-rex-core/src/core/config.rs
+++ b/t-rex-core/src/core/config.rs
@@ -96,6 +96,7 @@ pub struct TilesetCfg {
     //? pub minzoom: Option<u8>,
     //? pub maxzoom: Option<u8>,
     //? pub center: [0.0, 0.0, 2],
+    pub attribution: Option<String>,
     #[serde(rename = "layer")]
     pub layers: Vec<LayerCfg>,
     // Inline style

--- a/t-rex-core/src/service/tileset.rs
+++ b/t-rex-core/src/service/tileset.rs
@@ -11,6 +11,7 @@ use core::config::TilesetCfg;
 /// Collection of layers in one MVT
 pub struct Tileset {
     pub name: String,
+    pub attribution: Option<String>,
     pub extent: Option<Extent>,
     pub layers: Vec<Layer>,
 }
@@ -28,6 +29,9 @@ impl Tileset {
     }
     pub fn maxzoom(&self) -> u8 {
         22 // TODO: from layers or config (see also MvtService#get_stylejson)
+    }
+    pub fn attribution(&self) -> String {
+        self.attribution.clone().unwrap_or("".to_string())
     }
     pub fn get_extent(&self) -> &Extent {
         self.extent.as_ref().unwrap_or(&WORLD_EXTENT)
@@ -53,6 +57,7 @@ impl<'a> Config<'a, TilesetCfg> for Tileset {
             .collect();
         Ok(Tileset {
             name: tileset_cfg.name.clone(),
+            attribution: tileset_cfg.attribution.clone(),
             extent: tileset_cfg.extent.clone(),
             layers: layers,
         })

--- a/t-rex-service/src/mvt_service.rs
+++ b/t-rex-service/src/mvt_service.rs
@@ -118,7 +118,7 @@ impl MvtService {
             "id": tileset,
             "name": tileset,
             "description": tileset,
-            "attribution": "",
+            "attribution": ts.attribution(),
             "format": "pbf",
             "version": "2.0.0",
             "scheme": "xyz",

--- a/t-rex-service/src/mvt_service_test.rs
+++ b/t-rex-service/src/mvt_service_test.rs
@@ -31,6 +31,7 @@ fn mvt_service() -> MvtService {
     layer.query_limit = Some(1);
     let tileset = Tileset {
         name: "points".to_string(),
+        attribution: Some("Attribution".to_string()),
         extent: Some(Extent {
             minx: -179.58998,
             miny: -90.00000,

--- a/t-rex-service/src/qgs_reader.rs
+++ b/t-rex-service/src/qgs_reader.rs
@@ -155,6 +155,7 @@ pub fn read_qgs(fname: &str) -> (Datasources, Tileset) {
     let mut datasources = Datasources::new();
     let mut tileset = Tileset {
         name: qgs_name.to_string(),
+        attribution: None,
         extent: None,
         layers: Vec::new(),
     };

--- a/t-rex-webserver/src/server.rs
+++ b/t-rex-webserver/src/server.rs
@@ -258,6 +258,7 @@ pub fn service_from_args(args: &ArgMatches) -> (MvtService, ApplicationCfg) {
                     set_layer_buffer_defaults(&mut l, simplify, clip);
                     let tileset = Tileset {
                         name: l.name.clone(),
+                        attribution: None,
                         extent: extent,
                         layers: vec![l],
                     };


### PR DESCRIPTION
Support `attribution` attribute from configuration file and render it in the tilejson descriptor.

```
-            "attribution": "",
+            "attribution": ts.attribution(),
```

```
+    pub fn attribution(&self) -> String {
+        self.attribution.clone().unwrap_or("".to_string())
+    }
```
I'm not sure about this. Should we keep to render empty string or null when there is no attribution.

Note: it's my first time on Rust.

This PR is more a test, tell me it I need change doc or other thing.
My primary interest is in render minzoom/maxzoom at tileset level from configuration file into tilejson descriptor.