### PR TITLE
Support minzoom, maxzoom, center & start_zoom from configuration file to tilejson descriptor

### DIFF
--- a/t-rex-core/src/core/config.rs
+++ b/t-rex-core/src/core/config.rs
@@ -169,6 +169,8 @@ predefined = "web_mercator"
 
 [[tileset]]
 name = ""
+minzoom = 0 # Optional override of zoom limits broadcasted to tilejson descriptor
+maxzoom = 22
 attribution = "© Contributeurs de OpenStreetMap" # Acknowledgment of ownership, authorship or copyright.
 
 [[tileset.layer]]

--- a/t-rex-core/src/core/config.rs
+++ b/t-rex-core/src/core/config.rs
@@ -93,9 +93,10 @@ pub struct UserGridCfg {
 pub struct TilesetCfg {
     pub name: String,
     pub extent: Option<Extent>,
-    //? pub minzoom: Option<u8>,
-    //? pub maxzoom: Option<u8>,
-    //? pub center: [0.0, 0.0, 2],
+    pub minzoom: Option<u8>,
+    pub maxzoom: Option<u8>,
+    pub center: Option<(f64, f64)>,
+    pub start_zoom: Option<u8>,
     pub attribution: Option<String>,
     #[serde(rename = "layer")]
     pub layers: Vec<LayerCfg>,

--- a/t-rex-core/src/core/layer.rs
+++ b/t-rex-core/src/core/layer.rs
@@ -135,6 +135,8 @@ impl<'a> Config<'a, LayerCfg> for Layer {
         let toml = r#"
 [[tileset]]
 name = "points"
+minzoom = 0 # Optional override of zoom limits broadcasted to tilejson descriptor
+maxzoom = 22
 attribution = "© Contributeurs de OpenStreetMap" # Acknowledgment of ownership, authorship or copyright.
 
 [[tileset.layer]]

--- a/t-rex-service/src/mvt_service_test.rs
+++ b/t-rex-service/src/mvt_service_test.rs
@@ -31,6 +31,8 @@ fn mvt_service() -> MvtService {
     layer.query_limit = Some(1);
     let tileset = Tileset {
         name: "points".to_string(),
+        minzoom: None,
+        maxzoom: Some(14),
         attribution: Some("Attribution".to_string()),
         extent: Some(Extent {
             minx: -179.58998,

--- a/t-rex-service/src/mvt_service_test.rs
+++ b/t-rex-service/src/mvt_service_test.rs
@@ -31,8 +31,10 @@ fn mvt_service() -> MvtService {
     layer.query_limit = Some(1);
     let tileset = Tileset {
         name: "points".to_string(),
-        minzoom: None,
-        maxzoom: Some(14),
+        minzoom: Some(0),
+        maxzoom: Some(22),
+        center: None,
+        start_zoom: Some(3),
         attribution: Some("Attribution".to_string()),
         extent: Some(Extent {
             minx: -179.58998,
@@ -471,6 +473,8 @@ predefined = "web_mercator"
 
 [[tileset]]
 name = "points"
+minzoom = 0 # Optional override of zoom limits broadcasted to tilejson descriptor
+maxzoom = 22
 attribution = "© Contributeurs de OpenStreetMap" # Acknowledgment of ownership, authorship or copyright.
 
 [[tileset.layer]]

--- a/t-rex-service/src/qgs_reader.rs
+++ b/t-rex-service/src/qgs_reader.rs
@@ -155,8 +155,12 @@ pub fn read_qgs(fname: &str) -> (Datasources, Tileset) {
     let mut datasources = Datasources::new();
     let mut tileset = Tileset {
         name: qgs_name.to_string(),
+        minzoom: None,
+        maxzoom: None,
         attribution: None,
         extent: None,
+        center: None,
+        start_zoom: None,
         layers: Vec::new(),
     };
     for qgslayer in projectlayers.find_all("maplayer") {

--- a/t-rex-webserver/src/server.rs
+++ b/t-rex-webserver/src/server.rs
@@ -258,8 +258,12 @@ pub fn service_from_args(args: &ArgMatches) -> (MvtService, ApplicationCfg) {
                     set_layer_buffer_defaults(&mut l, simplify, clip);
                     let tileset = Tileset {
                         name: l.name.clone(),
+                        minzoom: None,
+                        maxzoom: None,
                         attribution: None,
                         extent: extent,
+                        center: None,
+                        start_zoom: None,
                         layers: vec![l],
                     };
                     tilesets.push(tileset);


### PR DESCRIPTION
Render minzoom/maxzoom and map center and zoom at tileset level from configuration file into tilejson descriptor.

I split map center and zoom because toml does not support array of mixed type. Option<(f64, f64, u8)> is not loadable from config file.