### PR TITLE
Prevent invalid geometries in vector tiles

### DIFF
--- a/t-rex-core/src/mvt/geom_encoder.rs
+++ b/t-rex-core/src/mvt/geom_encoder.rs
@@ -127,7 +127,7 @@ impl EncodableGeom for screen::MultiPoint {
 
 impl EncodableGeom for screen::LineString {
     fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
-        if self.points.len() > 0 {
+        if self.points.len() > 1 {
             self.points[0].encode_from(startpos, seq);
             seq.push(CommandInteger::new(Command::LineTo, (self.points.len() - 1) as u32).0);
             for i in 1..self.points.len() {
@@ -142,7 +142,7 @@ impl EncodableGeom for screen::LineString {
 impl screen::LineString {
     fn encode_ring_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
         // almost same as LineString.encode_from, with ClosePath instead of last point
-        if self.points.len() > 0 {
+        if self.points.len() > 3 {
             self.points[0].encode_from(startpos, seq);
             seq.push(CommandInteger::new(Command::LineTo, (self.points.len() - 2) as u32).0);
             for i in 1..self.points.len() - 1 {

--- a/t-rex-core/src/mvt/tile.rs
+++ b/t-rex-core/src/mvt/tile.rs
@@ -91,9 +91,11 @@ impl ScreenGeom<geom::LineString> for screen::LineString {
                 extent, reverse_y, tile_size, point,
             ));
         }
+        screen_geom.points.dedup();
         screen_geom
     }
 }
+
 
 impl ScreenGeom<geom::MultiLineString> for screen::MultiLineString {
     fn from_geom(
@@ -260,9 +262,11 @@ impl<'a> Tile<'a> {
             );
         }
         if let Ok(geom) = feature.geometry() {
-            if !geom.is_empty() {
-                mvt_feature.set_field_type(geom.mvt_field_type());
-                mvt_feature.set_geometry(self.encode_geom(geom, mvt_layer.get_extent()).vec());
+            let g_type = geom.mvt_field_type();
+            let enc_geom = self.encode_geom(geom, mvt_layer.get_extent()).vec();
+            if !enc_geom.is_empty() {
+                mvt_feature.set_field_type(g_type);
+                mvt_feature.set_geometry(enc_geom);
                 mvt_layer.mut_features().push(mvt_feature);
             }
         }


### PR DESCRIPTION
Prevent invalid geometries in vector tiles by 

- filtering repeated points and
- check for minimum number of points required for a valid geometry

This PR addresses problems 1., 2. and 3. of #115 