### PR TITLE
Fix for SSL to PostgreSQL and added sslmode=required explicit parameter to URL connection string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "dotenv 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "t-rex-core 0.9.9",
  "t-rex-gdal 0.9.9",
  "t-rex-service 0.9.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dotenv = "0.14.1"
 log = "0.4"
 env_logger = "0.6"
 time = "0.1"
+regex = "1.3.9"
 
 [features]
 default = ["with-gdal"]


### PR DESCRIPTION
The TLS mode error message did not match with the error from the database, so TLS mode was never triggered in our situation (Azure PostgreSQL). Fixed by adding 'SSL connection is required' to the error messages.

Because of the backoff algorithm the connection with TLS took about 30 seconds more. (30 seconds of failing to setup a non TLS connection before trying to connect with TLS). By accepting the sslmode=require parameter in the connection string this 30 seconds is skipped and TLS is immediately tried. 

We have batch jobs with around 125.000 connections, so a 30 second extra wait for a PostgreSQL connection is quite substantial