### PR TITLE
added docker-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ t-rex
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/o60e9bu97i49lxyf?svg=true)](https://ci.appveyor.com/project/pka/t-rex)
 [![Language (Rust)](https://img.shields.io/badge/powered_by-Rust-blue.svg)](http://www.rust-lang.org/)
 [![Discord Chat](https://img.shields.io/discord/598002550221963289.svg)](https://discord.gg/Fp2aape)
+[![Docker Pulls](https://img.shields.io/docker/pulls/sourcepole/t-rex.svg)](https://hub.docker.com/r/sourcepole/t-rex)
 
 t-rex is a vector tile server specialized on publishing [MVT tiles](https://github.com/mapbox/vector-tile-spec/tree/master/2.1)
 from your own data.


### PR DESCRIPTION
Personally I didn't even realized the was a 'official' docker image, after seeing issue https://github.com/t-rex-tileserver/t-rex/issues/221 😄 
So maybe it would be nice to add a badge for the docker image.