### PR TITLE
Add key_prefix option to S3 cache

### DIFF
--- a/examples/s3.toml
+++ b/examples/s3.toml
@@ -29,13 +29,14 @@ make_valid = true
 table_name = "ne_110m_admin_0_countries"
 
 [cache.s3]
-# run s3 locally and create bucket with:
+# run s3 locally and create bucket with (requires MinIO Client (mc) for bucket creation):
 # docker run -d --rm -p 9000:9000 -e MINIO_REGION_NAME=my-region -e MINIO_ACCESS_KEY=miniostorage -e MINIO_SECRET_KEY=miniostorage minio/minio server /data && sleep 5 && mc config host add local-docker http://localhost:9000 miniostorage miniostorage && mc mb local-docker/trex
 host = "http://localhost:9000"
 bucket = "trex"
 access_key = "miniostorage"
 secret_key = "miniostorage"
 region = "my-region"
+key_prefix = "my-prefix"
 
 [webserver]
 bind = "127.0.0.1"

--- a/t-rex-core/src/cache/mod.rs
+++ b/t-rex-core/src/cache/mod.rs
@@ -92,6 +92,7 @@ impl<'a> Config<'a, ApplicationCfg> for Tilecache {
                             &s3_cache_cfg.secret_key.clone(),
                             &s3_cache_cfg.region.clone(),
                             s3_cache_cfg.baseurl.clone(),
+                            s3_cache_cfg.key_prefix.clone(),
                         );
                         Tilecache::S3Cache(s3c)
                     } else {

--- a/t-rex-core/src/core/config.rs
+++ b/t-rex-core/src/core/config.rs
@@ -202,6 +202,7 @@ pub struct S3CacheFileCfg {
     pub secret_key: String,
     pub region: String,
     pub baseurl: Option<String>,
+    pub key_prefix: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
Add `key_prefix` option to S3 cache. To allow for storing the tilecache in a specific path, like:

```
my-bucket/my-prefix/tileset/...
````