### PR TITLE
renamed s3-cache host to endpoint

### DIFF
--- a/examples/s3.toml
+++ b/examples/s3.toml
@@ -31,7 +31,7 @@ table_name = "ne_110m_admin_0_countries"
 [cache.s3]
 # run s3 locally and create bucket with (requires MinIO Client (mc) for bucket creation):
 # docker run -d --rm -p 9000:9000 -e MINIO_REGION_NAME=my-region -e MINIO_ACCESS_KEY=miniostorage -e MINIO_SECRET_KEY=miniostorage minio/minio server /data && sleep 5 && mc config host add local-docker http://localhost:9000 miniostorage miniostorage && mc mb local-docker/trex
-host = "http://localhost:9000"
+endpoint = "http://localhost:9000"
 bucket = "trex"
 access_key = "miniostorage"
 secret_key = "miniostorage"

--- a/t-rex-core/src/cache/mod.rs
+++ b/t-rex-core/src/cache/mod.rs
@@ -86,7 +86,7 @@ impl<'a> Config<'a, ApplicationCfg> for Tilecache {
                         Tilecache::Filecache(fc)
                     } else if let Some(s3_cache_cfg) = cache.s3.as_ref() {
                         let s3c = S3Cache::new(
-                            &s3_cache_cfg.host.clone(),
+                            &s3_cache_cfg.endpoint.clone(),
                             &s3_cache_cfg.bucket.clone(),
                             &s3_cache_cfg.access_key.clone(),
                             &s3_cache_cfg.secret_key.clone(),

--- a/t-rex-core/src/core/config.rs
+++ b/t-rex-core/src/core/config.rs
@@ -196,7 +196,7 @@ pub struct CacheFileCfg {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct S3CacheFileCfg {
-    pub host: String,
+    pub endpoint: String,
     pub bucket: String,
     pub access_key: String,
     pub secret_key: String,

--- a/t-rex-core/src/core/config_test.rs
+++ b/t-rex-core/src/core/config_test.rs
@@ -69,7 +69,7 @@ fn test_template() {
         [cache.file]
         base = "/tmp/mvtcache"
         [cache.s3]
-        host = "s3.delivery.pdok.nl"
+        endpoint = "https://s3.example.com"
         region = "westeurope"
         bucket = "bucket"
         access_key = "access-key"


### PR DESCRIPTION
Renamed field to match naming convention in s3 lib. I am also working on a PR to add to the documentation, to wrap it all up.  