### PR TITLE
added optional srid to extent parameter of generate command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,20 @@ fn generate(args: &ArgMatches<'_>) {
             maxy: arr[3],
         })
     });
+
+    let extent_srid = args.value_of("extent").and_then(|numlist| {
+        let arr: Vec<&str> = numlist.split(",").collect();
+        match arr.len() {
+            5 => {
+                let srid = arr[4];
+                let srid_int: i32 = srid
+                    .parse()
+                    .expect("Error parsing 'srid' in 'extent' as integer");
+                Some(srid_int)
+            }
+            _ => None,
+        }
+    });
     let nodes = args.value_of("nodes").map(|s| {
         s.parse::<u8>()
             .expect("Error parsing 'nodes' as integer value")
@@ -92,7 +106,15 @@ fn generate(args: &ArgMatches<'_>) {
     });
     service.prepare_feature_queries();
     service.generate(
-        tileset, minzoom, maxzoom, extent, nodes, nodeno, progress, overwrite,
+        tileset,
+        minzoom,
+        maxzoom,
+        extent,
+        nodes,
+        nodeno,
+        progress,
+        overwrite,
+        extent_srid,
     );
 }
 
@@ -184,7 +206,7 @@ fn main() {
                                               --tileset=[NAME] 'Tileset name'
                                               --minzoom=[LEVEL] 'Minimum zoom level'
                                               --maxzoom=[LEVEL] 'Maximum zoom level'
-                                              --extent=[minx,miny,maxx,maxy] 'Extent of tiles'
+                                              --extent=[minx,miny,maxx,maxy[,srid]] 'Extent of tiles'
                                               --nodes=[NUM] 'Number of generator nodes'
                                               --nodeno=[NUM] 'Number of this nodes (0 <= n < nodes)'
                                               --progress=[true|false] 'Show progress bar'

--- a/t-rex-core/src/datasource/datasource.rs
+++ b/t-rex-core/src/datasource/datasource.rs
@@ -19,7 +19,12 @@ pub trait DatasourceType {
     fn layer_extent(&self, layer: &Layer, grid_srid: i32) -> Option<Extent>;
     fn prepare_queries(&mut self, tileset: &str, layer: &Layer, grid_srid: i32);
     /// Projected extent
-    fn extent_from_wgs84(&self, extent: &Extent, dest_srid: i32) -> Option<Extent>;
+    fn reproject_extent(
+        &self,
+        extent: &Extent,
+        dest_srid: i32,
+        src_srid: Option<i32>,
+    ) -> Option<Extent>;
     /// Retrieve features of one layer. Return feature count.
     fn retrieve_features<F>(
         &self,
@@ -47,7 +52,12 @@ impl DatasourceType for DummyDatasource {
     fn detect_data_columns(&self, _layer: &Layer, _sql: Option<&String>) -> Vec<(String, String)> {
         unimplemented!();
     }
-    fn extent_from_wgs84(&self, _extent: &Extent, _dest_srid: i32) -> Option<Extent> {
+    fn reproject_extent(
+        &self,
+        _extent: &Extent,
+        _dest_srid: i32,
+        _src_srid: Option<i32>,
+    ) -> Option<Extent> {
         unimplemented!();
     }
     fn layer_extent(&self, _layer: &Layer, _grid_srid: i32) -> Option<Extent> {

--- a/t-rex-core/src/datasource/postgis_ds.rs
+++ b/t-rex-core/src/datasource/postgis_ds.rs
@@ -611,10 +611,16 @@ impl DatasourceType for PostgisDatasource {
             .collect()
     }
     /// Projected extent
-    fn extent_from_wgs84(&self, extent: &Extent, dest_srid: i32) -> Option<Extent> {
+    fn reproject_extent(
+        &self,
+        extent: &Extent,
+        dest_srid: i32,
+        src_srid: Option<i32>,
+    ) -> Option<Extent> {
+        let ext_srid = src_srid.unwrap_or(4326);
         let sql = format!(
-            "SELECT ST_Transform(ST_MakeEnvelope({}, {}, {}, {}, 4326), {}) AS extent",
-            extent.minx, extent.miny, extent.maxx, extent.maxy, dest_srid
+            "SELECT ST_Transform(ST_MakeEnvelope({}, {}, {}, {}, {}), {}) AS extent",
+            extent.minx, extent.miny, extent.maxx, extent.maxy, ext_srid, dest_srid
         );
         self.extent_query(sql)
     }

--- a/t-rex-gdal/src/gdal_ds.rs
+++ b/t-rex-gdal/src/gdal_ds.rs
@@ -72,8 +72,14 @@ impl DatasourceType for GdalDatasource {
         Vec::new() //TODO
     }
     /// Projected extent
-    fn extent_from_wgs84(&self, extent: &Extent, dest_srid: i32) -> Option<Extent> {
-        transform_extent(extent, 4326, dest_srid).ok()
+    fn reproject_extent(
+        &self,
+        extent: &Extent,
+        dest_srid: i32,
+        src_srid: Option<i32>,
+    ) -> Option<Extent> {
+        let ext_srid = src_srid.unwrap_or(4326);
+        transform_extent(extent, ext_srid, dest_srid).ok()
     }
     fn layer_extent(&self, layer: &Layer, grid_srid: i32) -> Option<Extent> {
         let mut dataset = Dataset::open(Path::new(&self.path)).unwrap();

--- a/t-rex-gdal/src/gdal_ds_test.rs
+++ b/t-rex-gdal/src/gdal_ds_test.rs
@@ -140,12 +140,12 @@ fn test_coord_transformation() {
         }
     };
     assert_eq!(
-        ds.extent_from_wgs84(&extent_wgs84, 3857),
+        ds.reproject_extent(&extent_wgs84, 3857, None),
         Some(extent_3857.clone())
     );
 
     // Invalid input extent doesn't panic
-    let result = ds.extent_from_wgs84(&extent_3857, 3857);
+    let result = ds.reproject_extent(&extent_3857, 3857, None);
     assert!(result.is_none());
 
     let mut reccnt = 0;

--- a/t-rex-service/src/datasources.rs
+++ b/t-rex-service/src/datasources.rs
@@ -41,10 +41,15 @@ impl DatasourceType for Datasource {
             &Datasource::Gdal(ref ds) => ds.detect_data_columns(layer, sql),
         }
     }
-    fn extent_from_wgs84(&self, extent: &Extent, dest_srid: i32) -> Option<Extent> {
+    fn reproject_extent(
+        &self,
+        extent: &Extent,
+        dest_srid: i32,
+        src_srid: Option<i32>,
+    ) -> Option<Extent> {
         match self {
-            &Datasource::Postgis(ref ds) => ds.extent_from_wgs84(extent, dest_srid),
-            &Datasource::Gdal(ref ds) => ds.extent_from_wgs84(extent, dest_srid),
+            &Datasource::Postgis(ref ds) => ds.reproject_extent(extent, dest_srid, src_srid),
+            &Datasource::Gdal(ref ds) => ds.reproject_extent(extent, dest_srid, src_srid),
         }
     }
     fn layer_extent(&self, layer: &Layer, grid_srid: i32) -> Option<Extent> {

--- a/t-rex-service/src/mvt_service_test.rs
+++ b/t-rex-service/src/mvt_service_test.rs
@@ -294,7 +294,10 @@ fn test_projected_extent() {
         maxy: 6982997.920389788,
     };
 
-    assert_eq!(service.extent_from_wgs84(&extent_wgs84), extent_3857);
+    assert_eq!(
+        service.extent_from_input_extent(&extent_wgs84, None),
+        extent_3857
+    );
 }
 
 #[test]
@@ -320,6 +323,7 @@ fn test_generate() {
         None,
         false,
         false,
+        None,
     );
 }
 

--- a/tile-grid/src/grid.rs
+++ b/tile-grid/src/grid.rs
@@ -317,7 +317,7 @@ pub fn lonlat_to_merc(lon: f64, lat: f64) -> (f64, f64) {
 }
 
 /// Projected extent
-pub fn extent_to_merc(extent: &Extent) -> Extent {
+pub fn extent_wgs84_to_merc(extent: &Extent) -> Extent {
     let (minx, miny) = lonlat_to_merc(extent.minx, extent.miny);
     let (maxx, maxy) = lonlat_to_merc(extent.maxx, extent.maxy);
     Extent {

--- a/tile-grid/src/grid_test.rs
+++ b/tile-grid/src/grid_test.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-use crate::grid::{extent_to_merc, lonlat_to_merc, Extent, ExtentInt, Grid};
+use crate::grid::{extent_wgs84_to_merc, lonlat_to_merc, Extent, ExtentInt, Grid};
 
 #[test]
 fn test_bbox() {
@@ -217,7 +217,7 @@ fn test_projected_extent() {
         maxx: 556597.4539663679,
         maxy: 6982997.920389788,
     };
-    let projected = extent_to_merc(&extent_wgs84);
+    let projected = extent_wgs84_to_merc(&extent_wgs84);
     assert_eq!(projected, extent_3857);
     assert_eq!(
         lonlat_to_merc(extent_wgs84.minx, extent_wgs84.miny),

--- a/tile-grid/src/lib.rs
+++ b/tile-grid/src/lib.rs
@@ -70,5 +70,5 @@ mod grid_iterator;
 #[cfg(test)]
 mod grid_test;
 
-pub use grid::{extent_to_merc, Extent, ExtentInt, Grid, Origin, Unit};
+pub use grid::{extent_wgs84_to_merc, Extent, ExtentInt, Grid, Origin, Unit};
 pub use grid_iterator::GridIterator;


### PR DESCRIPTION
This PR adds an optional  srid item to the `--extent` parameter of the generate command like so:

```
generate --config config.toml --extent 132608.7000,475796.5511,154910.3484,497819.7047,28992  
``` 

In the above example the extent is in EPSG:28992 (Dutch national projection). 

The usecase for this is the following: in our case we generate tiles in EPSG:28992 and pretile the data, because the dataset contain some fairly big and complex geometries. These pretiled datasets need to tiled in different jobs that allign exactly, this is not possible with WGS84 extents. Reprojecting extents between WGS84 and RD slightly changes the extent. 
 
Also renamed some methods to better reflect the new situation. 
