### PR TITLE
Update gdal to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,15 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "gdal"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e77cdaf1ef2897806e2751104c09fe1118c8e86404eaeafa627ba26a3316769"
+checksum = "f05358ac96cd0a0420ef0fdb84e4d9039f6deb6c923a1643ecc8e19e34f7ca45"
 dependencies = [
- "gdal-sys",
+ "bitflags",
+ "gdal-sys 0.4.0",
  "geo-types",
  "libc",
- "num-traits",
  "semver 0.11.0",
  "thiserror",
 ]
@@ -1137,6 +1128,17 @@ name = "gdal-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b22f37a6352d986f4da60d44684a34c73179314854ad163334e223adffc6ca9"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "gdal-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a320e53209a395011eb98d413bd31a44c8f3b3f561eb3d49065775bd24491f"
 dependencies = [
  "libc",
  "pkg-config",
@@ -1164,11 +1166,10 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7583925a1fdb2b450c461fe0878ba6e99a8f1332b2bc72fb1383fd25b2f13bf2"
+checksum = "d8bd2e95dd9f5c8ff74159ed9205ad7fd239a9569173a550863976421b45d2bb"
 dependencies = [
- "approx",
  "num-traits",
 ]
 
@@ -2937,7 +2938,7 @@ name = "t-rex-gdal"
 version = "0.9.9"
 dependencies = [
  "gdal",
- "gdal-sys",
+ "gdal-sys 0.3.1",
  "log",
  "t-rex-core",
  "tile-grid",

--- a/t-rex-gdal/Cargo.toml
+++ b/t-rex-gdal/Cargo.toml
@@ -13,7 +13,7 @@ workspace = ".."
 doctest = false
 
 [dependencies]
-gdal = "0.7"
+gdal = "0.8"
 gdal-sys = "0.3"
 log = "0.4"
 

--- a/t-rex-gdal/src/gdal_ds_test.rs
+++ b/t-rex-gdal/src/gdal_ds_test.rs
@@ -20,10 +20,10 @@ fn gdal_version() -> i32 {
 
 #[test]
 fn test_gdal_api() {
-    let mut dataset = Dataset::open(Path::new("../data/natural_earth.gpkg")).unwrap();
-    let layer = dataset.layer_by_name("ne_10m_populated_places").unwrap();
+    let dataset = Dataset::open(Path::new("../data/natural_earth.gpkg")).unwrap();
+    let mut layer = dataset.layer_by_name("ne_10m_populated_places").unwrap();
     let feature = layer.features().next().unwrap();
-    let name_field = feature.field("NAME").unwrap();
+    let name_field = feature.field("NAME").unwrap().unwrap();
     let geometry = feature.geometry();
     assert_eq!(
         name_field.into_string(),
@@ -181,8 +181,8 @@ fn test_gdal_retrieve_multilines() {
         maxy: 5948635.3,
     };
 
-    let mut gdal_ds = Dataset::open(Path::new("../data/natural_earth.gpkg")).unwrap();
-    let gdal_layer = gdal_ds
+    let gdal_ds = Dataset::open(Path::new("../data/natural_earth.gpkg")).unwrap();
+    let mut gdal_layer = gdal_ds
         .layer_by_name(layer.table_name.as_ref().unwrap())
         .unwrap();
     assert_eq!(gdal_layer.features().count(), 1404);

--- a/t-rex-gdal/src/gdal_fields.rs
+++ b/t-rex-gdal/src/gdal_fields.rs
@@ -399,7 +399,7 @@ impl<'a> Feature for VectorFeature<'a> {
                         err
                     );
                     None
-                },
+                }
                 _ => {
                     warn!(
                         "Layer '{}' - skipping field '{}'",


### PR DESCRIPTION
We encountered a memory leak during the usage of t-rex. It turns out the memory leak is located in the gdal dependency and fixed in version 0.8.0. See pull request: https://github.com/georust/gdal/pull/172. This pull request updates the gdal library from version 0.7 to version 0.8.0.

There are some breaking changes in gdal 0.8.0 which we had to overcome. This is my first experience with Rust and some of my solutions might not be the right way to do thinks in Rust.

I tested t-rex with heaptrack and the memory leak seems to be fixed with the upgrade to 0.8.0.