### PR TITLE
choose dist-depending dependencies, version and package name by switch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
 
       - run: cargo install cargo-deb
 
-      - run: cargo deb
+      - run: cargo deb # --variant bullseye
 
       - name: Deb file
         id: deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,27 @@ with-gdal = ["t-rex-gdal", "t-rex-service/with-gdal"]
 
 [package.metadata.deb]
 maintainer = "Pirmin Kalberer <pi_deb@sourcepole.ch>"
-copyright = "2020, Pirmin Kalberer <pi_deb@sourcepole.ch>"
+copyright = "2021, Pirmin Kalberer <pi_deb@sourcepole.ch>"
 license-file = ["LICENSE", "4"]
 extended-description = """\
 t-rex is a vector tile server specialized \
 on publishing MVT tiles from your own data."""
-depends = "libssl1.1, libgdal26"
 section = "utility"
 priority = "optional"
 assets = [
     ["target/release/t_rex", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/t-rex/README", "644"],
 ]
+depends = "libssl1.1, libgdal26"
+revision = "1~focal"
+
+[package.metadata.deb.variants.focal]
+# default: is Ubuntu Focal Fossa 20.04 (LTS) 
+
+[package.metadata.deb.variants.buster]
+depends = "libssl1.1, libgdal20"
+revision = "1~buster"
+
+[package.metadata.deb.variants.bullseye]
+depends = "libssl1.1, libgdal28"
+revision = "1~bullseye"


### PR DESCRIPTION
## summary
This patch allows to select the depedencies for different distributions by switch `--variant`. A unique package version and name is chosen, which is different for each distribution.

## examples
- `cargo deb` or `cargo deb --variant focal` builds package `t-rex_0.14.0-1~focal_amd64.deb` with depencencies: `libssl1.1, libgdal26`
- `cargo deb --variant buster` builds package `t-rex_0.14.0-1~buster_amd64.deb` with depencencies: `libssl1.1, libgdal20`
- `cargo deb --variant bullseye` builds package `t-rex_0.14.0-1~bullseye_amd64.deb` with depencencies: `libssl1.1, libgdal28`

## notes
1. The naming schema doesn't suite the official Debian Packaging Guide. The version suffix `~bullseye` is usually quicker to recognize than `~deb11u1`.
2. Currently supported distributions: Ubuntu Focal Fossa (20.04, LTS), Debian Buster (10) and Debian Bullseye (11). Focal is the default (by the author's design).
3. Tasks still need to be created in the GitHub actions, which builds and packages `t-rex`  under the different distributions.