### PR TITLE
Fix naming scheme of deb-packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ with-gdal = ["t-rex-gdal", "t-rex-service/with-gdal"]
 [workspace]
 
 [package.metadata.deb]
+name = "t-rex"
 maintainer = "Pirmin Kalberer <pi_deb@sourcepole.ch>"
 copyright = "2021, Pirmin Kalberer <pi_deb@sourcepole.ch>"
 license-file = ["LICENSE", "4"]


### PR DESCRIPTION
This removes the duplicate variant name, which position was rather unexpected by fixing the metadata.

## example
- old: `t-rex-focal_0.14.1~pre5-1~focal_amd64.deb`
- new: `t-rex_0.14.1~pre5-1~focal_amd64.deb`