### PR TITLE
Delete outdated generated tiles

### DIFF
--- a/t-rex-core/src/cache/cache.rs
+++ b/t-rex-core/src/cache/cache.rs
@@ -15,6 +15,7 @@ pub trait Cache {
         F: FnMut(&mut dyn Read);
     fn write(&self, path: &str, obj: &[u8]) -> Result<(), io::Error>;
     fn exists(&self, path: &str) -> bool;
+    fn remove(&self, path: &str) -> bool;
 }
 
 #[derive(Clone)]
@@ -40,6 +41,9 @@ impl Cache for Nocache {
     }
 
     fn exists(&self, _path: &str) -> bool {
+        false
+    }
+    fn remove(&self, _path: &str) -> bool {
         false
     }
 }

--- a/t-rex-core/src/cache/filecache.rs
+++ b/t-rex-core/src/cache/filecache.rs
@@ -50,4 +50,12 @@ impl Cache for Filecache {
         let fullpath = format!("{}/{}", self.basepath, path);
         Path::new(&fullpath).exists()
     }
+
+    fn remove(&self, path: &str) -> bool {
+        let fullpath = format!("{}/{}", self.basepath, path);
+        match fs::remove_file(fullpath) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
 }

--- a/t-rex-core/src/cache/mod.rs
+++ b/t-rex-core/src/cache/mod.rs
@@ -67,6 +67,14 @@ impl Cache for Tilecache {
             &Tilecache::S3Cache(ref cache) => cache.exists(path),
         }
     }
+
+    fn remove(&self, path: &str) -> bool {
+        match self {
+            &Tilecache::Nocache(ref cache) => cache.remove(path),
+            &Tilecache::Filecache(ref cache) => cache.remove(path),
+            &Tilecache::S3Cache(ref cache) => cache.remove(path),
+        }
+    }
 }
 
 impl<'a> Config<'a, ApplicationCfg> for Tilecache {

--- a/t-rex-core/src/cache/s3cache.rs
+++ b/t-rex-core/src/cache/s3cache.rs
@@ -6,7 +6,9 @@
 use crate::cache::cache::Cache;
 use rusoto_core::{Client, HttpClient, Region};
 use rusoto_credential::StaticProvider;
-use rusoto_s3::{GetObjectRequest, HeadObjectRequest, PutObjectRequest, S3Client, S3};
+use rusoto_s3::{
+    DeleteObjectRequest, GetObjectRequest, HeadObjectRequest, PutObjectRequest, S3Client, S3,
+};
 use std::io::{self, Read};
 use std::path::Path;
 
@@ -152,6 +154,23 @@ impl Cache for S3Cache {
             ..Default::default()
         };
         let response = self.client.head_object(request).sync();
+        match response {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+
+    fn remove(&self, path: &str) -> bool {
+        let key = self.full_path(path);
+        if key.is_empty() {
+            return false;
+        }
+        let request = DeleteObjectRequest {
+            bucket: self.bucket_name.to_owned(),
+            key: key.to_owned(),
+            ..Default::default()
+        };
+        let response = self.client.delete_object(request).sync();
         match response {
             Ok(_) => true,
             Err(_) => false,

--- a/t-rex-service/src/mvt_service.rs
+++ b/t-rex-service/src/mvt_service.rs
@@ -341,8 +341,8 @@ impl MvtService {
                 ytile
             };
             let path = format!("{}/{}/{}/{}.pbf", tileset_name, zoom, xtile, y);
-
-            if overwrite || !self.cache.exists(&path) {
+            let cache_exists = self.cache.exists(&path);
+            if overwrite || !cache_exists {
                 // Entry doesn't exist, or overwrite is forced, so generate it
                 let svc = self.clone();
                 let cache = self.cache.clone();
@@ -360,6 +360,8 @@ impl MvtService {
                         if let Err(ioerr) = cache.write(&path, &tilegz) {
                             error!("Error writing {}: {}", path, ioerr);
                         }
+                    } else if overwrite && cache_exists {
+                        cache.remove(&path);
                     }
                 }));
                 if tasks.len() >= task_queue_size {


### PR DESCRIPTION
In this PR added remove operation. When `--overwrite` flag in [t_rex generate](https://t-rex.tileserver.ch/doc/generate/#usage), specified then old (for which no features) tiles will be removed.

See #270 