### PR TITLE
update usergrid example to ol7

### DIFF
--- a/examples/usergrid.html
+++ b/examples/usergrid.html
@@ -1,80 +1,119 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>LV95 Grid</title>
-    <link rel="stylesheet" href="http://openlayers.org/en/v3.18.2/css/ol.css" type="text/css">
-    <script src="http://openlayers.org/en/v3.18.2/build/ol-debug.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.3/proj4.js" type="text/javascript"></script>
-    <style>
-      .map {
-        background: #f8f4f0;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="map" class="map"></div>
-    <script>
-      if (proj4) {
-        proj4.defs("EPSG:2056", "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs");
-        proj4.defs("EPSG:21781", "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs");
-      }
 
-      var RESOLUTIONS = [
-        4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
-        1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5
-      ];
+<head>
+  <title>LV95 Grid</title>
+  <script src="https://cdn.jsdelivr.net/npm/ol@7.2.2/dist/ol.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/ol@7.2.2/ol.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/proj4@2.8.1/dist/proj4.min.js"></script>
+  <style>
+    body {
+      font-family: sans, "Helvetica";
+    }
 
-      var extent = [2420000, 1030000, 2900000, 1350000];
-      var projection = ol.proj.get("EPSG:2056");
-      projection.setExtent(extent);
+    .map {
+      height: 600px;
+      top: 3em;
+      width: 100%;
+      background: #f8f4f0;
+    }
+  </style>
+</head>
 
-      var matrixIds = [];
-      for (var i = 0; i < RESOLUTIONS.length; i++) {
-        matrixIds.push(i);
-      }
+<body>
+  <h2>Custom User Grid (Swiss LV95)</h2>
+  <div id="map" class="map"></div>
+  <script>
 
-      var tileGrid = new ol.tilegrid.WMTS({
-        origin: [extent[0], extent[3]],
-        resolutions: RESOLUTIONS,
-        matrixIds: matrixIds
-      });
+    /* Custom resolutions, from Swiss norm eCH-0056 (https://www.ech.ch/fr/ech/ech-0056/3.0) */
+    const RESOLUTIONS = [
+      4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+      1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5
+    ];
 
-      var wmtsLayer = new ol.layer.Tile({
-        source: new ol.source.WMTS(({
-          url: 'https://wmts10.geo.admin.ch/1.0.0/{Layer}/default/20140620/2056/{TileMatrix}/{TileCol}/{TileRow}.jpeg',
-          tileGrid: tileGrid,
-          projection: projection,
-          layer: "ch.swisstopo.swissimage",
-          requestEncoding: 'REST'
-        }))
-      });
+    /* Registering and setting a new custom projection */
+    proj4.defs("EPSG:2056", "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs");
+    ol.proj.proj4.register(proj4);
 
-      var style = new ol.style.Style({
-        stroke: new ol.style.Stroke({
-          color: '#FFFF33',
-          width: 3
-        })
-      });
+    var extent = [2420000, 1030000, 2900000, 1350000];
+    var projection = ol.proj.get("EPSG:2056");
+    projection.setExtent(extent);
 
-      var vtLayer = new ol.layer.VectorTile({
-        source: new ol.source.VectorTile({
-          format: new ol.format.MVT(),
-          tileGrid: tileGrid,
-          tilePixelRatio: 16,
-          url: 'http://localhost:6767/g1k18/{z}/{x}/{y}.pbf'
-        }),
-        style: style
-      });
 
-      var map = new ol.Map({
-        layers: [wmtsLayer,vtLayer],
-        target: 'map',
-        view: new ol.View({
-          center: [2660000, 1190000],
-          projection: projection,
-          resolution: 500
-        })
-      });
-    </script>
-  </body>
+    /* Convenience methods for trying new layers */
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const layername = urlParams.get('layer') || 'g1k18'
+    const debug = urlParams.get('debug') || false;
+    const servername = urlParams.get('server') || location.origin;
+
+    /* Setting up the custom grid */
+    var matrixIds = [];
+    for (var i = 0; i < RESOLUTIONS.length; i++) {
+      matrixIds.push(i);
+    }
+
+    var tileGrid = new ol.tilegrid.WMTS({
+      origin: [extent[0], extent[3]],
+      resolutions: RESOLUTIONS,
+      matrixIds: matrixIds
+    });
+
+    /* Trusted WMTS raster layer */
+
+    var wmtsLayer = new ol.layer.Tile({
+      source: new ol.source.WMTS(({
+        url: 'https://wmts.geo.admin.ch/1.0.0/{Layer}/default/current/2056/{TileMatrix}/{TileCol}/{TileRow}.jpeg',
+        tileGrid: tileGrid,
+        projection: projection,
+        layer: "ch.swisstopo.swissimage",
+        requestEncoding: 'REST'
+      }))
+    });
+
+    /* Vector layer of interest  */
+
+    var style = new ol.style.Style({
+      stroke: new ol.style.Stroke({
+        color: '#FFFF33',
+        width: 3
+      })
+    });
+
+    var vtLayer = new ol.layer.VectorTile({
+      source: new ol.source.VectorTile({
+        format: new ol.format.MVT(),
+        tileGrid: tileGrid,
+        tilePixelRatio: 16,
+        url: servername + '/' + layername + '/{z}/{x}/{y}.pbf',
+        projection: projection
+      }),
+      style: style
+    });
+
+    /* Displaying the tiles names, for debugging */
+    const tileDebug = new ol.layer.Tile({
+      source: new ol.source.TileDebug({
+        projection: vtLayer.getSource().getProjection(),
+        tileGrid: vtLayer.getSource().getTileGrid(),
+      })
+    });
+
+    /* View and vector projection have to match, no reprojection like for raster layers */
+    var map = new ol.Map({
+      layers: [wmtsLayer, vtLayer],
+      target: 'map',
+      view: new ol.View({
+        center: [2660000, 1190000],
+        projection: projection,
+        resolution: 500
+      })
+    });
+
+    if (debug) {
+      map.addLayer(tileDebug);
+    }
+  </script>
+</body>
+
 </html>

--- a/examples/usergrid.toml
+++ b/examples/usergrid.toml
@@ -1,10 +1,18 @@
 # t-rex configuration
 
+# To run this example (self-contained datasource)
+# cd t_rex
+# t_rex serve --loglevel debug  --config examples/usergrid.toml
+# and navigate to http://127.0.0.1:6767/static/usergrid.html
+
 [service.mvt]
 viewer = true
 
+
 [[datasource]]
-dbconn = "postgresql://t_rex:t_rex@127.0.0.1:5439/t_rex_tests"
+path = "./data/g1k18.shp"
+name = "datasource"
+default = true
 
 [grid.user]
 width = 256
@@ -18,21 +26,24 @@ origin = "TopLeft"
 
 [[tileset]]
 name = "g1k18"
-extent = [5.96438, 45.81937, 10.55886, 47.77210]
+extent = [5.96455, 45.81936, 10.55885, 47.77213]
 
 [[tileset.layer]]
 name = "g1k18"
-geometry_field = "wkb_geometry"
-geometry_type = "MULTIPOLYGON"
-fid_field = "ktnr"
+table_name = "g1k18"
+geometry_field = ""
+geometry_type = "POLYGON"
 srid = 2056
-buffer_size = 2
+buffer_size = 1
+#make_valid = true
 simplify = true
-[[tileset.layer.query]]
-sql = """SELECT wkb_geometry,ktnr::FLOAT8,ktname FROM geostat.g1k18 WHERE wkb_geometry && !bbox!"""
+query_limit = 1000
+
+#[[tileset.layer.query]]
 
 #[cache.file]
 #base = "/tmp/mvtcache"
+#baseurl = "http://example.com/tiles"
 
 [webserver]
 # Bind address. Use 0.0.0.0 to listen on all adresses.


### PR DESCRIPTION
Updating the `usergrid` example to `OL7`, using a local `shapefile`as datasource and providing some some context doc (no functional changes).
Config generated with `t_rex genconfig`