### PR TITLE
gdal version bump + rename to_geo>to_geom naming conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "gdal"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0298f86d1a41cb625d887f4e932b40060fc7ab51e3052701234ba3326e11e1f"
+checksum = "c01d034014ff4d9f29ea3bf5bde5d191d98a154bc3accebde7c8c00341c9b98a"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "gdal-sys"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8331ad3efd6032c03f2462785468edceeb79371b43757ff29809f2d160575f0f"
+checksum = "dc578b8a84a9c950dfc110ef134f592181db19745b4ef46bf92039adf0af2dad"
 dependencies = [
  "libc",
  "pkg-config",

--- a/t-rex-gdal/Cargo.toml
+++ b/t-rex-gdal/Cargo.toml
@@ -13,8 +13,8 @@ workspace = ".."
 doctest = false
 
 [dependencies]
-gdal = "0.12"
-gdal-sys = "0.6"
+gdal = "0.14"
+gdal-sys = "0.8"
 log = "0.4"
 tile-grid = { path = "../tile-grid" }
 t-rex-core = { path = "../t-rex-core" }

--- a/t-rex-gdal/src/gdal_ds.rs
+++ b/t-rex-gdal/src/gdal_ds.rs
@@ -6,6 +6,7 @@
 use crate::gdal_fields::*;
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
 use gdal::vector::Geometry;
+use gdal::vector::LayerAccess;
 use gdal::Dataset;
 use std::collections::BTreeMap;
 use std::path::Path;

--- a/t-rex-gdal/src/gdal_ds_test.rs
+++ b/t-rex-gdal/src/gdal_ds_test.rs
@@ -4,8 +4,8 @@
 //
 
 use crate::gdal_ds::GdalDatasource;
-use gdal::Dataset;
 use gdal::vector::LayerAccess;
+use gdal::Dataset;
 use std::path::Path;
 use t_rex_core::core::feature::FeatureAttrValType;
 use t_rex_core::core::layer::Layer;

--- a/t-rex-gdal/src/gdal_ds_test.rs
+++ b/t-rex-gdal/src/gdal_ds_test.rs
@@ -5,6 +5,7 @@
 
 use crate::gdal_ds::GdalDatasource;
 use gdal::Dataset;
+use gdal::vector::LayerAccess;
 use std::path::Path;
 use t_rex_core::core::feature::FeatureAttrValType;
 use t_rex_core::core::layer::Layer;

--- a/t-rex-gdal/src/gdal_fields.rs
+++ b/t-rex-gdal/src/gdal_fields.rs
@@ -4,9 +4,9 @@
 //
 
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
+use gdal::vector::LayerAccess;
 use gdal::vector::{FieldValue, Geometry};
 use gdal::Dataset;
-use gdal::vector::LayerAccess;
 use gdal_sys;
 use std::path::Path;
 use t_rex_core::core::feature::{Feature, FeatureAttr, FeatureAttrValType};

--- a/t-rex-gdal/src/gdal_fields.rs
+++ b/t-rex-gdal/src/gdal_fields.rs
@@ -6,6 +6,7 @@
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
 use gdal::vector::{FieldValue, Geometry};
 use gdal::Dataset;
+use gdal::vector::LayerAccess;
 use gdal_sys;
 use std::path::Path;
 use t_rex_core::core::feature::{Feature, FeatureAttr, FeatureAttrValType};
@@ -195,18 +196,18 @@ pub mod OGRwkbGeometryType {
     pub const wkbGeometryCollection25D: Type = 2147483655;
 }
 
-trait ToGeo {
-    fn to_geo(&self, srid: Option<i32>) -> GeometryType;
+trait ToGeoM {
+    fn to_geom(&self, srid: Option<i32>) -> GeometryType;
 }
 
-impl ToGeo for Geometry {
+impl ToGeoM for Geometry {
     /// Convert OGR geomtry to t-rex EWKB geometry type (XY only)
-    fn to_geo(&self, srid: Option<i32>) -> GeometryType {
+    fn to_geom(&self, srid: Option<i32>) -> GeometryType {
         let geometry_type = self.geometry_type();
 
         let ring = |n: usize| {
             let ring = unsafe { self.get_unowned_geometry(n) };
-            return match ring.to_geo(srid) {
+            return match ring.to_geom(srid) {
                 GeometryType::LineString(r) => r,
                 _ => panic!("Expected to get a LineString"),
             };
@@ -231,7 +232,7 @@ impl ToGeo for Geometry {
                 let point_count = self.geometry_count();
                 let coords = (0..point_count)
                     .map(
-                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geo(srid) {
+                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geom(srid) {
                             GeometryType::Point(p) => p,
                             _ => panic!("Expected to get a Point"),
                         },
@@ -267,7 +268,7 @@ impl ToGeo for Geometry {
                 let string_count = self.geometry_count();
                 let strings = (0..string_count)
                     .map(
-                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geo(srid) {
+                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geom(srid) {
                             GeometryType::LineString(s) => s,
                             _ => panic!("Expected to get a LineString"),
                         },
@@ -296,7 +297,7 @@ impl ToGeo for Geometry {
                 let string_count = self.geometry_count();
                 let strings = (0..string_count)
                     .map(
-                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geo(srid) {
+                        |n| match unsafe { self.get_unowned_geometry(n) }.to_geom(srid) {
                             GeometryType::Polygon(s) => s,
                             _ => panic!("Expected to get a Polygon"),
                         },
@@ -432,6 +433,6 @@ impl<'a> Feature for VectorFeature<'a> {
         if let Some(ref transform) = self.transform {
             ogrgeom.transform_inplace(transform).unwrap();
         };
-        Ok(ogrgeom.to_geo(Some(self.grid_srid)))
+        Ok(ogrgeom.to_geom(Some(self.grid_srid)))
     }
 }


### PR DESCRIPTION
Update dependencies gdal 0.12.0 -> 0.14.0 and gdal-sys 0.6.0 -> 0.8.0.
As stated in https://github.com/t-rex-tileserver/t-rex/issues/294 there needed to be some code changes.
Like `use gdal::vector::LayerAccess` 
but mainly renaming the `fn to_geo` -> `to_geom` (quick fix) because gdal::vector::Geometry now also has a `fn to_geo` https://github.com/georust/gdal/blob/master/src/vector/geometry.rs#L483