### PR TITLE
Ubuntu/Debian needs clang too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ t-rex is written in [Rust](https://www.rust-lang.org/). Minimal required rustc v
 
 Ubuntu 20.04 (Focal Fossa):
 
-    sudo apt install cargo libssl-dev libgdal-dev
+    sudo apt install cargo libssl-dev libgdal-dev clang
 
 ### Build and run
 


### PR DESCRIPTION
Otherwise you get the folling error:

    --- stderr
      /usr/include/stdio.h:33:10: fatal error: 'stddef.h' file not found
      thread 'main' panicked at /home/amanda/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gdal-sys-0.8.0/build.rs:31:10:
      Unable to generate bindings: ClangDiagnostic("/usr/include/stdio.h:33:10: fatal error: 'stddef.h' file not found\n")