### PR TITLE
Correct the mbtiles metadata format.

### DIFF
--- a/t-rex-service/src/metadata.rs
+++ b/t-rex-service/src/metadata.rs
@@ -275,8 +275,19 @@ impl MvtService {
     // -> {tileset}/metadata.json
     pub fn get_mbtiles_metadata(&self, tileset: &str, grid: &Grid) -> JsonResult {
         let mut metadata = self.get_tilejson_metadata(tileset, grid)?;
-        metadata["bounds"] = json!(metadata["bounds"].to_string());
-        metadata["center"] = json!(metadata["center"].to_string());
+        metadata["bounds"] = format!(
+            "{},{},{},{}",
+            metadata["bounds"][0],
+            metadata["bounds"][1],
+            metadata["bounds"][2],
+            metadata["bounds"][3]
+        )
+        .into();
+        metadata["center"] = format!(
+            "{},{},{}",
+            metadata["center"][0], metadata["center"][1], metadata["center"][2]
+        )
+        .into();
         let layers = self.get_tilejson_layers(tileset)?;
         let vector_layers = self.get_tilejson_vector_layers(tileset)?;
         let metadata_vector_layers = json!({


### PR DESCRIPTION
The TileJSON format says that `bounds` & `centre` are arrays of numbers. But the mbtiles `metadata` table requires that it's a string o 4 comma separated numbers

If you don't do this, then `mbutil` can't convert the directory to a `mbtiles` file. You get this error:

    Traceback (most recent call last):
      File "/home/amanda/.local/bin//mb-util", line 89, in <module>
	disk_to_mbtiles(directory_path, mbtiles_file, **options.__dict__)
      File "/home/amanda/.local/pipx/venvs/mbutil/lib/python3.11/site-packages/mbutil/util.py", line 174, in disk_to_mbtiles
	cur.execute('insert into metadata (name, value) values (?, ?)',
    sqlite3.ProgrammingError: Error binding parameter 2: type 'list' is not supported

https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#content https://github.com/mapbox/tilejson-spec/blob/84008d750e54f37739e24785276596f40ccafeab/2.2.0/schema.json#L59-L70